### PR TITLE
Force freq set

### DIFF
--- a/src/src/main.c
+++ b/src/src/main.c
@@ -30,6 +30,7 @@ static void start_serial(uint8_t type)
       break;
     default:
       baud = 115200;
+      stopbits = 1;
       break;
   }
   serial_begin(baud, UART_TX, UART_RX, stopbits);
@@ -50,7 +51,7 @@ void setup(void)
   start_serial(myEEPROM.vtxMode);
 
   rtc6705ResetState(); // During testing registers got messed up. So now it gets reset on boot!
-  rtc6705WriteFrequency(myEEPROM.currFreq);
+  rtc6705WriteFrequency(myEEPROM.currFreq, TRUE);
 
   status_leds_init();
 

--- a/src/src/main.c
+++ b/src/src/main.c
@@ -58,7 +58,7 @@ void setup(void)
   // TODO DEBUG! Below flashing is just for testing. Delete later.
 #if DEBUG
   myEEPROM.currFreq = 5600;
-  rtc6705WriteFrequency(myEEPROM.currFreq);
+  rtc6705WriteFrequency(myEEPROM.currFreq, FALSE);
 
   // target_set_power_dB(0);
   target_set_power_dB(14);

--- a/src/src/rtc6705.c
+++ b/src/src/rtc6705.c
@@ -69,7 +69,7 @@ void rtc6705PowerAmpOff(void)
   amp_state = 0;
 }
 
-void rtc6705WriteFrequency(uint32_t newFreq, uint8_t forceSet)
+void rtc6705WriteFrequency(uint32_t newFreq, uint8_t forceSet) // forceSet is needed for the initial write during setup, otherwise it does nothing and A1 is set by default.
 {
   uint32_t freq = newFreq * 1000U;
   freq /= 40;

--- a/src/src/rtc6705.c
+++ b/src/src/rtc6705.c
@@ -69,7 +69,7 @@ void rtc6705PowerAmpOff(void)
   amp_state = 0;
 }
 
-void rtc6705WriteFrequency(uint32_t newFreq)
+void rtc6705WriteFrequency(uint32_t newFreq, uint8_t forceSet)
 {
   uint32_t freq = newFreq * 1000U;
   freq /= 40;
@@ -79,7 +79,7 @@ void rtc6705WriteFrequency(uint32_t newFreq)
   uint32_t data = SynthesizerRegisterB | (1 << 4) | (SYN_RF_A_REG << 5) | (SYN_RF_N_REG << 12);
 
   /* Don't write if not changed -> avoid blinking */
-  if (newFreq == myEEPROM.currFreq)
+  if (newFreq == myEEPROM.currFreq && !forceSet)
     return;
 
   myEEPROM.currFreq = newFreq;

--- a/src/src/rtc6705.c
+++ b/src/src/rtc6705.c
@@ -71,19 +71,19 @@ void rtc6705PowerAmpOff(void)
 
 void rtc6705WriteFrequency(uint32_t newFreq, uint8_t forceSet) // forceSet is needed for the initial write during setup, otherwise it does nothing and A1 is set by default.
 {
-  uint32_t freq = newFreq * 1000U;
-  freq /= 40;
-  uint32_t SYN_RF_N_REG = freq / 64;
-  uint32_t SYN_RF_A_REG = freq % 64;
-
-  uint32_t data = SynthesizerRegisterB | (1 << 4) | (SYN_RF_A_REG << 5) | (SYN_RF_N_REG << 12);
-
   /* Don't write if not changed -> avoid blinking */
   if (newFreq == myEEPROM.currFreq && !forceSet)
     return;
 
   myEEPROM.currFreq = newFreq;
   updateEEPROM = 1;
+
+  uint32_t freq = newFreq * 1000U;
+  freq /= 40;
+  uint32_t SYN_RF_N_REG = freq / 64;
+  uint32_t SYN_RF_A_REG = freq % 64;
+
+  uint32_t data = SynthesizerRegisterB | (1 << 4) | (SYN_RF_A_REG << 5) | (SYN_RF_N_REG << 12);
 
   /* Switch off */
   amp_state = 1; // Force off cmd rewrite

--- a/src/src/rtc6705.h
+++ b/src/src/rtc6705.h
@@ -20,4 +20,4 @@ void sendBits(uint32_t data);
 void rtc6705ResetState(void);
 void rtc6705PowerAmpOn(void);
 void rtc6705PowerAmpOff(void);
-void rtc6705WriteFrequency(uint32_t newFreq, uint8_t forceSet = 0);
+void rtc6705WriteFrequency(uint32_t newFreq, uint8_t forceSet);

--- a/src/src/rtc6705.h
+++ b/src/src/rtc6705.h
@@ -20,4 +20,4 @@ void sendBits(uint32_t data);
 void rtc6705ResetState(void);
 void rtc6705PowerAmpOn(void);
 void rtc6705PowerAmpOff(void);
-void rtc6705WriteFrequency(uint32_t newFreq);
+void rtc6705WriteFrequency(uint32_t newFreq, uint8_t forceSet = 0);

--- a/src/src/smartAudio.c
+++ b/src/src/smartAudio.c
@@ -164,7 +164,7 @@ void smartaudioProcessFrequencyPacket(void)
     }
     else
     {
-        rtc6705WriteFrequency(freq);
+        rtc6705WriteFrequency(freq, FALSE);
         myEEPROM.freqMode = 1;
     }
 
@@ -184,7 +184,7 @@ void smartaudioProcessChannelPacket(void)
 
     if (channel < ARRAY_SIZE(channelFreqTable)) {
         myEEPROM.channel = channel;
-        rtc6705WriteFrequency(channelFreqTable[channel]);
+        rtc6705WriteFrequency(channelFreqTable[channel], FALSE);
         myEEPROM.freqMode = 0;
     } else {
         channel = myEEPROM.channel;

--- a/src/src/targets/EWRF_E7082VM/EWRF_E7082VM.c
+++ b/src/src/targets/EWRF_E7082VM/EWRF_E7082VM.c
@@ -210,7 +210,7 @@ void taget_loop(void)
       {
         myEEPROM.currFreq = 5600;
       }
-      rtc6705WriteFrequency(myEEPROM.currFreq);
+      rtc6705WriteFrequency(myEEPROM.currFreq, FALSE);
     }
     #endif /* OUTPUT_POWER_TESTING */
   }

--- a/src/src/tramp.c
+++ b/src/src/tramp.c
@@ -88,7 +88,7 @@ void trampProcessFPacket(void)
     uint32_t freq = rxPacket[3];
     freq <<= 8;
     freq |= rxPacket[2];
-    rtc6705WriteFrequency(freq);
+    rtc6705WriteFrequency(freq, FALSE);
 }
 
 void trampProcessPPacket(void)


### PR DESCRIPTION
Required to make the initial rtc6705WriteFrequency in setup write.

If BF is configured for F4 the freq isnt set and A1 set by default on boot of the rtc6705.