### PR TITLE
Fixes startup and freq changing blips

### DIFF
--- a/src/src/common.c
+++ b/src/src/common.c
@@ -10,6 +10,7 @@ uint8_t rxPacket[16];
 uint8_t txPacket[18];
 uint8_t vtxModeLocked;
 uint8_t pitMode = 0;
+uint8_t initFreqPacketRecived = 0;
 
 void clearSerialBuffer(void)
 {
@@ -87,6 +88,9 @@ void setPowerdB(float dB)
 {
     myEEPROM.currPowerdB = dB;
     updateEEPROM = 1;
+
+    if (!initFreqPacketRecived)
+      return;
 
     if (pitMode)
     {

--- a/src/src/common.h
+++ b/src/src/common.h
@@ -15,6 +15,7 @@ extern uint8_t txPacket[18];
 extern uint8_t vtxModeLocked;
 extern uint8_t pitMode;
 
+extern uint8_t initFreqPacketRecived;
 
 void clearSerialBuffer(void);
 void zeroRxPacket(void);

--- a/src/src/main.c
+++ b/src/src/main.c
@@ -90,6 +90,8 @@ void loop(void)
   else
     smartaudioProcessSerial();
 
+  rtc6705PowerUpAfterPLLSettleTime();
+  
   checkPowerOutput();
 
   // writeEEPROM();

--- a/src/src/main.c
+++ b/src/src/main.c
@@ -48,10 +48,10 @@ void setup(void)
 
   pitMode = myEEPROM.pitmodeInRange;
 
-  start_serial(myEEPROM.vtxMode);
-
   rtc6705ResetState(); // During testing registers got messed up. So now it gets reset on boot!
   rtc6705WriteFrequency(myEEPROM.currFreq);
+
+  start_serial(myEEPROM.vtxMode);
 
   status_leds_init();
 

--- a/src/src/main.c
+++ b/src/src/main.c
@@ -51,7 +51,7 @@ void setup(void)
   start_serial(myEEPROM.vtxMode);
 
   rtc6705ResetState(); // During testing registers got messed up. So now it gets reset on boot!
-  rtc6705WriteFrequencyForce(myEEPROM.currFreq);
+  rtc6705WriteFrequency(myEEPROM.currFreq);
 
   status_leds_init();
 

--- a/src/src/openVTxEEPROM.c
+++ b/src/src/openVTxEEPROM.c
@@ -12,7 +12,7 @@ void defaultEEPROM(void)
 {
     myEEPROM.version = versionEEPROM;
     myEEPROM.vtxMode = TRAMP;
-    myEEPROM.currFreq = 5801;
+    myEEPROM.currFreq = BOOT_FREQ;
     myEEPROM.channel = 255;
     myEEPROM.freqMode = 0;
     myEEPROM.pitmodeInRange = 0;

--- a/src/src/openVTxEEPROM.c
+++ b/src/src/openVTxEEPROM.c
@@ -12,8 +12,8 @@ void defaultEEPROM(void)
 {
     myEEPROM.version = versionEEPROM;
     myEEPROM.vtxMode = TRAMP;
-    myEEPROM.currFreq = 5800;
-    myEEPROM.channel = 27;
+    myEEPROM.currFreq = 5801;
+    myEEPROM.channel = 255;
     myEEPROM.freqMode = 0;
     myEEPROM.pitmodeInRange = 0;
     myEEPROM.pitmodeOutRange = 0;

--- a/src/src/openVTxEEPROM.h
+++ b/src/src/openVTxEEPROM.h
@@ -4,6 +4,8 @@
 
 #define versionEEPROM 0x110
 
+#define BOOT_FREQ 5000
+
 extern uint8_t updateEEPROM;
 
 typedef enum

--- a/src/src/rtc6705.c
+++ b/src/src/rtc6705.c
@@ -9,6 +9,7 @@ static gpio_out_t sck_pin;
 static gpio_out_t mosi_pin;
 static uint_fast8_t amp_state;
 
+static uint32_t powerUpAfterSettleTime = 0;
 
 void spiPinSetup(void)
 {
@@ -90,13 +91,20 @@ void rtc6705WriteFrequency(uint32_t newFreq)
   rtc6705PowerAmpOff();
   target_set_power_dB(0);
 
-  delay(500);
-
   /* Set frequency */
   sendBits(data);
 
-  delay(500);
-  
-  /* Restore state */
-  setPowerdB(myEEPROM.currPowerdB);
+  powerUpAfterSettleTime = millis() + PLL_SETTLE_TIME;
+}
+
+void rtc6705PowerUpAfterPLLSettleTime()
+{
+  if (!powerUpAfterSettleTime)
+    return;
+
+  if (powerUpAfterSettleTime < millis())
+  {
+    setPowerdB(myEEPROM.currPowerdB);
+    powerUpAfterSettleTime = 0;
+  }
 }

--- a/src/src/rtc6705.c
+++ b/src/src/rtc6705.c
@@ -52,21 +52,21 @@ void rtc6705ResetState(void)
 
 void rtc6705PowerAmpOn(void)
 {
-  if (amp_state) return;
-  uint32_t data = PredriverandPAControlRegister | (1 << 4) | (0b10011111011111100000);
+  // if (amp_state) return;
+  // uint32_t data = PredriverandPAControlRegister | (1 << 4) | (0b10011111011111100000);
 
-  sendBits(data);
-  amp_state = 1;
+  // sendBits(data);
+  // amp_state = 1;
 }
 
 void rtc6705PowerAmpOff(void)
 {
-  if (!amp_state) return;
+  // if (!amp_state) return;
 
-  uint32_t data = PredriverandPAControlRegister | (1 << 4);
+  // uint32_t data = PredriverandPAControlRegister | (1 << 4);
 
-  sendBits(data);
-  amp_state = 0;
+  // sendBits(data);
+  // amp_state = 0;
 }
 
 void rtc6705WriteFrequency(uint32_t newFreq)
@@ -88,7 +88,7 @@ void rtc6705WriteFrequency(uint32_t newFreq)
   /* Switch off */
   amp_state = 1; // Force off cmd rewrite
   rtc6705PowerAmpOff();
-  target_set_power_dB(0);
+  // target_set_power_dB(0);
 
   /* Set frequency */
   sendBits(data);

--- a/src/src/rtc6705.c
+++ b/src/src/rtc6705.c
@@ -72,7 +72,7 @@ void rtc6705PowerAmpOff(void)
 void rtc6705WriteFrequency(uint32_t newFreq)
 {
   /* Don't write if not changed -> avoid blinking */
-  if (newFreq == myEEPROM.currFreq)
+  if (newFreq == myEEPROM.currFreq && newFreq != BOOT_FREQ)
     return;
 
   myEEPROM.currFreq = newFreq;

--- a/src/src/rtc6705.c
+++ b/src/src/rtc6705.c
@@ -52,21 +52,21 @@ void rtc6705ResetState(void)
 
 void rtc6705PowerAmpOn(void)
 {
-  // if (amp_state) return;
-  // uint32_t data = PredriverandPAControlRegister | (1 << 4) | (0b10011111011111100000);
+  if (amp_state) return;
+  uint32_t data = PredriverandPAControlRegister | (1 << 4) | (0b10011111011111100000);
 
-  // sendBits(data);
-  // amp_state = 1;
+  sendBits(data);
+  amp_state = 1;
 }
 
 void rtc6705PowerAmpOff(void)
 {
-  // if (!amp_state) return;
+  if (!amp_state) return;
 
-  // uint32_t data = PredriverandPAControlRegister | (1 << 4);
+  uint32_t data = PredriverandPAControlRegister | (1 << 4);
 
-  // sendBits(data);
-  // amp_state = 0;
+  sendBits(data);
+  amp_state = 0;
 }
 
 void rtc6705WriteFrequency(uint32_t newFreq)
@@ -88,7 +88,7 @@ void rtc6705WriteFrequency(uint32_t newFreq)
   /* Switch off */
   amp_state = 1; // Force off cmd rewrite
   rtc6705PowerAmpOff();
-  // target_set_power_dB(0);
+  target_set_power_dB(0);
 
   /* Set frequency */
   sendBits(data);

--- a/src/src/rtc6705.c
+++ b/src/src/rtc6705.c
@@ -90,9 +90,13 @@ void rtc6705WriteFrequency(uint32_t newFreq)
   rtc6705PowerAmpOff();
   target_set_power_dB(0);
 
+  delay(500);
+
   /* Set frequency */
   sendBits(data);
 
+  delay(500);
+  
   /* Restore state */
   setPowerdB(myEEPROM.currPowerdB);
 }

--- a/src/src/rtc6705.c
+++ b/src/src/rtc6705.c
@@ -71,18 +71,8 @@ void rtc6705PowerAmpOff(void)
 
 void rtc6705WriteFrequency(uint32_t newFreq)
 {
-  rtc6705WriteFreq(newFreq, FALSE);
-}
-
-void rtc6705WriteFrequencyForce(uint32_t newFreq)
-{
-  rtc6705WriteFreq(newFreq, TRUE);
-}
-
-void rtc6705WriteFreq(uint32_t newFreq, uint8_t forceSet)
-{
   /* Don't write if not changed -> avoid blinking */
-  if (newFreq == myEEPROM.currFreq && !forceSet)
+  if (newFreq == myEEPROM.currFreq)
     return;
 
   myEEPROM.currFreq = newFreq;

--- a/src/src/rtc6705.h
+++ b/src/src/rtc6705.h
@@ -20,6 +20,4 @@ void sendBits(uint32_t data);
 void rtc6705ResetState(void);
 void rtc6705PowerAmpOn(void);
 void rtc6705PowerAmpOff(void);
-void rtc6705WriteFreq(uint32_t newFreq, uint8_t forceSet);
 void rtc6705WriteFrequency(uint32_t newFreq);
-void rtc6705WriteFrequencyForce(uint32_t newFreq);

--- a/src/src/rtc6705.h
+++ b/src/src/rtc6705.h
@@ -15,9 +15,12 @@
 #define MIN_FREQ 5000
 #define MAX_FREQ 5999
 
+#define PLL_SETTLE_TIME 500
+
 void spiPinSetup(void);
 void sendBits(uint32_t data);
 void rtc6705ResetState(void);
 void rtc6705PowerAmpOn(void);
 void rtc6705PowerAmpOff(void);
 void rtc6705WriteFrequency(uint32_t newFreq);
+void rtc6705PowerUpAfterPLLSettleTime();

--- a/src/src/smartAudio.c
+++ b/src/src/smartAudio.c
@@ -145,6 +145,8 @@ void smartaudioBuildSettingsPacket(void)
 
 void smartaudioProcessFrequencyPacket(void)
 {
+    initFreqPacketRecived = 1;
+
     sa_u16_resp_t * payload =
         (sa_u16_resp_t*)fill_resp_header(
             SA_CMD_SET_FREQ, sizeof(sa_u16_resp_t));
@@ -177,6 +179,8 @@ void smartaudioProcessFrequencyPacket(void)
 
 void smartaudioProcessChannelPacket(void)
 {
+    initFreqPacketRecived = 1;
+    
     sa_u8_resp_t * payload =
         (sa_u8_resp_t*)fill_resp_header(
             SA_CMD_SET_CHAN, sizeof(sa_u8_resp_t));

--- a/src/src/tramp.c
+++ b/src/src/tramp.c
@@ -85,6 +85,8 @@ void trampBuildsPacket(void)
 
 void trampProcessFPacket(void)
 {
+    initFreqPacketRecived = 1;
+    
     uint32_t freq = rxPacket[3];
     freq <<= 8;
     freq |= rxPacket[2];


### PR DESCRIPTION
Delays are needed for the RTC6705 PLL to settle and the output frequency to be correct.  The amp is then powered up after the settling delay.

Todo- the first delay may not be necessary and the second may be able to be decreased. Testing required.

Boot frequency was also changed to out of range.

Output power will also not be set on boot before a frequency packet is received.