### PR TITLE
enable eeprom

### DIFF
--- a/src/src/common.c
+++ b/src/src/common.c
@@ -8,7 +8,7 @@
 
 uint8_t rxPacket[16];
 uint8_t txPacket[18];
-uint8_t vtxModeLocked = 0;
+uint8_t vtxModeLocked;
 uint8_t pitMode = 0;
 
 void clearSerialBuffer(void)

--- a/src/src/common.c
+++ b/src/src/common.c
@@ -8,9 +8,8 @@
 
 uint8_t rxPacket[16];
 uint8_t txPacket[18];
-uint8_t vtxModeLocked;
+uint8_t vtxModeLocked = 0;
 uint8_t pitMode = 0;
-uint8_t initFreqPacketRecived = 0;
 
 void clearSerialBuffer(void)
 {
@@ -87,10 +86,7 @@ void status_led3(uint8_t state)
 void setPowerdB(float dB)
 {
     myEEPROM.currPowerdB = dB;
-    updateEEPROM = 1;
-
-    if (!initFreqPacketRecived)
-      return;
+    updateEEPROM();
 
     if (pitMode)
     {
@@ -106,7 +102,7 @@ void setPowerdB(float dB)
 void setPowermW(uint16_t mW)
 {
     myEEPROM.currPowermW = mW;
-    updateEEPROM = 1;
+    updateEEPROM();
 
     float dB = 10.0 * log10((float)mW);
     setPowerdB(dB);

--- a/src/src/common.h
+++ b/src/src/common.h
@@ -17,8 +17,6 @@ extern uint8_t txPacket[18];
 extern uint8_t vtxModeLocked;
 extern uint8_t pitMode;
 
-extern uint8_t initFreqPacketRecived;
-
 void clearSerialBuffer(void);
 void zeroRxPacket(void);
 void zeroTxPacket(void);

--- a/src/src/main.c
+++ b/src/src/main.c
@@ -36,7 +36,7 @@ static void start_serial(uint8_t type)
   }
   serial_begin(baud, UART_TX, UART_RX, stopbits);
   myEEPROM.vtxMode = type;
-  updateEEPROM = 1;
+  updateEEPROM();
 }
 
 void checkRTC6705isAlive()
@@ -57,8 +57,7 @@ void setup(void)
   target_rfPowerAmpPinSetup();
   rtc6705spiPinSetup();
 
-  // readEEPROM();
-  defaultEEPROM();
+  readEEPROM();
 
   pitMode = myEEPROM.pitmodeInRange;
 
@@ -69,16 +68,6 @@ void setup(void)
 
   status_leds_init();
 
-  // TODO DEBUG! Below flashing is just for testing. Delete later.
-#if DEBUG
-  myEEPROM.currFreq = 5600;
-  rtc6705WriteFrequency(myEEPROM.currFreq);
-
-  // target_set_power_dB(0);
-  target_set_power_dB(14);
-  // target_set_power_dB(20);
-  // target_set_power_dB(26);
-#endif /* DEBUG */
 }
 
 void loop(void)
@@ -120,7 +109,7 @@ void loop(void)
 
   errorCheck();
 
-  // writeEEPROM();
+  writeEEPROM();
 
   taget_loop();
   status_led2(vtxModeLocked);

--- a/src/src/openVTxEEPROM.c
+++ b/src/src/openVTxEEPROM.c
@@ -4,9 +4,12 @@
 
 
 openVTxEEPROM myEEPROM;
-uint32_t eeprom_last_write;
-uint8_t updateEEPROM;
+uint32_t eeprom_last_write = 0;
 
+void updateEEPROM(void)
+{
+    eeprom_last_write = millis();
+}
 
 void defaultEEPROM(void)
 {
@@ -21,7 +24,7 @@ void defaultEEPROM(void)
     myEEPROM.currPowermW = 0; // Required due to rounding errors when converting between dBm and mW
     myEEPROM.unlocked = 1;
 
-    updateEEPROM = 1;
+    updateEEPROM();
 }
 
 void readEEPROM(void)
@@ -31,15 +34,13 @@ void readEEPROM(void)
     if (myEEPROM.version != versionEEPROM) {
         defaultEEPROM();
     }
-    eeprom_last_write = millis();
 }
 
 void writeEEPROM(void)
 {
     uint32_t const now = millis();
-    if (updateEEPROM && 1000 <= (now - eeprom_last_write)) {
+    if (eeprom_last_write && (1000 < (now - eeprom_last_write))) {
         EEPROM_put(0, myEEPROM);
-        updateEEPROM = 0;
-        eeprom_last_write = now;
+        eeprom_last_write = 0;
     }
 }

--- a/src/src/openVTxEEPROM.h
+++ b/src/src/openVTxEEPROM.h
@@ -2,11 +2,11 @@
 
 #include <stdint.h>
 
-#define versionEEPROM 0x110
+#define versionEEPROM 0x0001
 
 #define BOOT_FREQ 5000
 
-extern uint8_t updateEEPROM;
+extern uint32_t eeprom_last_write;
 
 typedef enum
 {
@@ -33,6 +33,7 @@ typedef struct
 
 extern openVTxEEPROM myEEPROM;
 
+void updateEEPROM(void);
 void defaultEEPROM(void);
 void readEEPROM(void);
 void writeEEPROM(void);

--- a/src/src/openVTxEEPROM.h
+++ b/src/src/openVTxEEPROM.h
@@ -6,8 +6,6 @@
 
 #define BOOT_FREQ 5000
 
-extern uint32_t eeprom_last_write;
-
 typedef enum
 {
   TRAMP,
@@ -32,6 +30,7 @@ typedef struct
 } openVTxEEPROM;
 
 extern openVTxEEPROM myEEPROM;
+uint32_t eeprom_last_write;
 
 void updateEEPROM(void);
 void defaultEEPROM(void);

--- a/src/src/openVTxEEPROM.h
+++ b/src/src/openVTxEEPROM.h
@@ -30,7 +30,6 @@ typedef struct
 } openVTxEEPROM;
 
 extern openVTxEEPROM myEEPROM;
-uint32_t eeprom_last_write;
 
 void updateEEPROM(void);
 void defaultEEPROM(void);

--- a/src/src/rtc6705.c
+++ b/src/src/rtc6705.c
@@ -141,7 +141,7 @@ uint8_t rtc6705CheckFrequency()
 void rtc6705WriteFrequency(uint32_t newFreq)
 {
   myEEPROM.currFreq = newFreq;
-  updateEEPROM = 1;
+  updateEEPROM();
 
   uint32_t freq = newFreq * 1000U;
   freq /= 40;

--- a/src/src/smartAudio.c
+++ b/src/src/smartAudio.c
@@ -145,8 +145,6 @@ void smartaudioBuildSettingsPacket(void)
 
 void smartaudioProcessFrequencyPacket(void)
 {
-    initFreqPacketRecived = 1;
-
     sa_u16_resp_t * payload =
         (sa_u16_resp_t*)fill_resp_header(
             SA_CMD_SET_FREQ, sizeof(sa_u16_resp_t));
@@ -179,8 +177,6 @@ void smartaudioProcessFrequencyPacket(void)
 
 void smartaudioProcessChannelPacket(void)
 {
-    initFreqPacketRecived = 1;
-    
     sa_u8_resp_t * payload =
         (sa_u8_resp_t*)fill_resp_header(
             SA_CMD_SET_CHAN, sizeof(sa_u8_resp_t));
@@ -276,7 +272,7 @@ void smartaudioProcessModePacket(void)
         setPowerdB(myEEPROM.currPowerdB);
     }
 
-    updateEEPROM = 1;
+    updateEEPROM();
 
     bitWrite(operationMode, 0, myEEPROM.pitmodeInRange);
     bitWrite(operationMode, 1, myEEPROM.pitmodeOutRange);

--- a/src/src/tramp.c
+++ b/src/src/tramp.c
@@ -112,11 +112,11 @@ void trampProcessIPacket(void)
         setPowerdB(14);
     } else
     {
-        setPowerdB(myEEPROM.currPowermW);
+        setPowermW(myEEPROM.currPowermW);
     }
 
-    myEEPROM.pitmodeInRange = pitMode;  // Pitmode set via CMS is not remembered with Tramp, but I have forced it here to be useful like SA pitmode.
-    myEEPROM.pitmodeOutRange = 0;       // Set to 0 so only one of PIR or POR is set for smartaudio
+    // myEEPROM.pitmodeInRange = pitMode;  // Pitmode set via CMS is not remembered with Tramp, but I have forced it here to be useful like SA pitmode.
+    // myEEPROM.pitmodeOutRange = 0;       // Set to 0 so only one of PIR or POR is set for smartaudio
 
     updateEEPROM();
 }

--- a/src/src/tramp.c
+++ b/src/src/tramp.c
@@ -85,8 +85,6 @@ void trampBuildsPacket(void)
 
 void trampProcessFPacket(void)
 {
-    initFreqPacketRecived = 1;
-    
     uint32_t freq = rxPacket[3];
     freq <<= 8;
     freq |= rxPacket[2];
@@ -120,7 +118,7 @@ void trampProcessIPacket(void)
     myEEPROM.pitmodeInRange = pitMode;  // Pitmode set via CMS is not remembered with Tramp, but I have forced it here to be useful like SA pitmode.
     myEEPROM.pitmodeOutRange = 0;       // Set to 0 so only one of PIR or POR is set for smartaudio
 
-    updateEEPROM = 1;
+    updateEEPROM();
 }
 
 enum {


### PR DESCRIPTION
Thanks PeHo :muscle:

Slightly changed writeEEPROM() condition to only write after the last change.  Previously it would write immediately after the first of multiple changes and then again 1s later after more changes.

Pitmode logic is a little broken on boot and needs addressing.