### PR TITLE
fix RACE_MODE

### DIFF
--- a/src/src/main.c
+++ b/src/src/main.c
@@ -59,7 +59,8 @@ void setup(void)
 
   readEEPROM();
 
-  pitMode = myEEPROM.pitmodeInRange;
+  // pitMode = myEEPROM.pitmodeInRange;
+  pitMode = myEEPROM.currPowerdB == RACE_MODE;
 
   rtc6705ResetState(); // During testing registers got messed up. So now it gets reset on boot!
   rtc6705WriteFrequency(myEEPROM.currFreq);

--- a/src/src/smartAudio.c
+++ b/src/src/smartAudio.c
@@ -242,7 +242,7 @@ void smartaudioProcessModePacket(void)
             SA_CMD_SET_MODE, sizeof(sa_u8_resp_t));
     uint8_t data = rxPacket[4], operationMode = 0;
 
-    uint8_t previousPitmodeInRange = myEEPROM.pitmodeInRange;
+    // uint8_t previousPitmodeInRange = myEEPROM.pitmodeInRange;
 
     // Set PIR and POR. POR is no longer used in SA2.1 and is treated like PIR
     myEEPROM.pitmodeInRange = bitRead(data, 0);
@@ -265,12 +265,11 @@ void smartaudioProcessModePacket(void)
     }
 
     // When turning on pitmodeInRange go into pitmode
-    if (previousPitmodeInRange < myEEPROM.pitmodeInRange)
-    {
-        /* Enable pitmode if PIR is set */
-        pitMode = 1;
-        setPowerdB(myEEPROM.currPowerdB);
-    }
+    // if (previousPitmodeInRange < myEEPROM.pitmodeInRange)
+    // {
+    //     pitMode = 1;
+    //     setPowerdB(myEEPROM.currPowerdB);
+    // }
 
     updateEEPROM();
 

--- a/src/src/tramp.c
+++ b/src/src/tramp.c
@@ -100,7 +100,7 @@ void trampProcessPPacket(void)
     if (mW == RACE_MODE)
     {
         pitMode = 1;
-        myEEPROM.currPowerdB = 2; // currPowerdB is set because it is used in setup() to check RACE_MODE
+        myEEPROM.currPowerdB = RACE_MODE; // currPowerdB is set because it is used in setup() to check RACE_MODE
     }
     
     setPowermW(mW);

--- a/src/src/tramp.c
+++ b/src/src/tramp.c
@@ -98,7 +98,10 @@ void trampProcessPPacket(void)
     mW += rxPacket[2];
 
     if (mW == RACE_MODE)
+    {
         pitMode = 1;
+        myEEPROM.currPowerdB = 2; // currPowerdB is set because it is used in setup() to check RACE_MODE
+    }
     
     setPowermW(mW);
 }


### PR DESCRIPTION
With the addition of eeprom RACE_MODE needed to be fixed and force pitmode on boot.

This PR also comments out pitmodeInRange and pitmodeOutRange in preference of RACE_MODE.