### PR TITLE
Fix SA power indexing

### DIFF
--- a/src/src/common.h
+++ b/src/src/common.h
@@ -9,7 +9,8 @@
 
 #define FLIGHT_CONTROLLER_CHECK_TIMEOUT 3000
 
-#define RACE_MODE 2
+#define RACE_MODE       2
+#define RACE_MODE_POWER 14 // dBm
 
 extern uint8_t rxPacket[16];
 extern uint8_t txPacket[18];

--- a/src/src/targets/EWRF_E7082VM/EWRF_E7082VM.c
+++ b/src/src/targets/EWRF_E7082VM/EWRF_E7082VM.c
@@ -10,7 +10,14 @@
 
 #define OUTPUT_POWER_INTERVAL 5 // ms
 
-uint8_t powerLevels[] = {0, 1, 14, 20, 26}; // SA2.1 powerlevels dBm. Currently only used for Inav and a max of 5.
+/* SA2.1 powerlevels in dBm.
+ *
+ * INav:
+ *    Max of 5 [https://github.com/iNavFlight/inav/blob/a8016edd0d6f05bb12a75b0ea75a3483772baaeb/src/main/io/vtx_smartaudio.h#L36]
+ *    Index 0 is ignored [https://github.com/iNavFlight/inav/blob/a8016edd0d6f05bb12a75b0ea75a3483772baaeb/src/main/io/vtx_smartaudio.c#L334]
+ *
+ */
+uint8_t saPowerLevelsLut[SA_NUM_POWER_LEVELS] = {0, 1, 14, 20, 26};
 
 gpio_pwm_t outputPowerTimer;
 gpio_out_t vref_pin;

--- a/src/src/targets/EWRF_E7082VM/EWRF_E7082VM.h
+++ b/src/src/targets/EWRF_E7082VM/EWRF_E7082VM.h
@@ -4,7 +4,7 @@
 #define MAX_POWER     400 // mW
 
 #define SA_NUM_POWER_LEVELS 5 // Max 5 for INAV.
-extern uint8_t powerLevels[];
+extern uint8_t saPowerLevelsLut[SA_NUM_POWER_LEVELS];
 
 #define UART_RX       PA9
 #define UART_TX       PA9

--- a/src/src/tramp.c
+++ b/src/src/tramp.c
@@ -5,7 +5,6 @@
 #include "targets.h"
 #include "serial.h"
 
-uint16_t temperature = 0; // Dummy value.
 
 #define TRAMP_HEADER    0x0F // 15
 #define TRAMP_MSG_SIZE  15
@@ -75,6 +74,8 @@ void trampBuildvPacket(void)
 
 void trampBuildsPacket(void)
 {
+    uint16_t temperature = 0; // Dummy value.
+
     zeroTxPacket();
     txPacket[0] = TRAMP_HEADER;
     txPacket[1] = 's';
@@ -86,7 +87,7 @@ void trampBuildsPacket(void)
 void trampProcessFPacket(void)
 {
     initFreqPacketRecived = 1;
-    
+
     uint32_t freq = rxPacket[3];
     freq <<= 8;
     freq |= rxPacket[2];
@@ -101,7 +102,7 @@ void trampProcessPPacket(void)
 
     if (mW == RACE_MODE)
         pitMode = 1;
-    
+
     setPowermW(mW);
 }
 


### PR DESCRIPTION
 Fix the case where power indices are used instead of dBms (SA2.0).
 
 Some firmwares are sending indices even the reported SA version is 2.1. This fixes the issue. 
 
 ~~Also report RACE_MODE in list of power values (default will be `{RACE_MODE, 1, 14, 20, 26}`) . This is safe since iNav ignores the first index and BF uses user defined values so it can be used by others if needed.~~