### PR TITLE
removes build_flag flto

### DIFF
--- a/src/platformio.ini
+++ b/src/platformio.ini
@@ -54,7 +54,6 @@ src_filter =
 	${env.src_filter}
 	+<gd32f1x0/*.c>
 build_flags =
-	-flto
 	-Wall
 	-Werror
 	-Wextra


### PR DESCRIPTION
GD32 doesnt appear to be booting. Removing build flasg flto that was introduced in https://github.com/OpenVTx/OpenVTx/pull/34 fixes the issue.