### PR TITLE
SA: fix power index search when pitmode is enabled

### DIFF
--- a/src/src/smartAudio.c
+++ b/src/src/smartAudio.c
@@ -72,9 +72,9 @@ typedef struct {
 } sa_u16_resp_t;
 
 
-uint8_t findPowerIndexFromLut(uint8_t dBm)
+static uint8_t findPowerIndexFromLut(uint8_t const dBm)
 {
-    if (pitMode) {
+    if (!pitMode) {
         for (uint8_t i = 0; i < ARRAY_SIZE(saPowerLevelsLut); i++) {
             if (dBm == saPowerLevelsLut[i]) {
                 return i;


### PR DESCRIPTION
Power is find from LUT is not working properly since pitmode check is wrong.