### PR TITLE
Correct WD and eeprom

### DIFF
--- a/src/src/common.c
+++ b/src/src/common.c
@@ -10,7 +10,6 @@ uint8_t rxPacket[16];
 uint8_t txPacket[18];
 uint8_t vtxModeLocked;
 uint8_t pitMode = 0;
-uint8_t initFreqPacketRecived = 0;
 
 void clearSerialBuffer(void)
 {
@@ -88,9 +87,6 @@ void setPowerdB(float dB)
 {
     myEEPROM.currPowerdB = dB;
     updateEEPROM = 1;
-
-    if (!initFreqPacketRecived)
-      return;
 
     if (pitMode)
     {

--- a/src/src/common.c
+++ b/src/src/common.c
@@ -95,7 +95,7 @@ void setPowerdB(float dB)
     } else
     {
       rtc6705PowerAmpOn();
-      target_set_power_dB(myEEPROM.currPowerdB);
+      target_set_power_dB(dB);
     }
 }
 

--- a/src/src/common.c
+++ b/src/src/common.c
@@ -86,7 +86,7 @@ void status_led3(uint8_t state)
 void setPowerdB(float dB)
 {
     myEEPROM.currPowerdB = dB;
-    updateEEPROM = 1;
+    updateEEPROM();
 
     if (pitMode)
     {
@@ -95,14 +95,13 @@ void setPowerdB(float dB)
     } else
     {
       rtc6705PowerAmpOn();
-      target_set_power_dB(dB);
+      target_set_power_dB(myEEPROM.currPowerdB);
     }
 }
 
 void setPowermW(uint16_t mW)
 {
     myEEPROM.currPowermW = mW;
-    updateEEPROM = 1;
 
     float dB = 10.0 * log10f((float)mW);  // avoid double conversion!
     setPowerdB(dB);

--- a/src/src/common.h
+++ b/src/src/common.h
@@ -21,8 +21,6 @@ extern uint8_t txPacket[18];
 extern uint8_t vtxModeLocked;
 extern uint8_t pitMode;
 
-extern uint8_t initFreqPacketRecived;
-
 void clearSerialBuffer(void);
 void zeroRxPacket(void);
 void zeroTxPacket(void);

--- a/src/src/gd32f1x0/EEPROM.c
+++ b/src/src/gd32f1x0/EEPROM.c
@@ -43,8 +43,12 @@ static int flash_storage_write(uint32_t const * data, uint32_t size)
     if (!data || !size || EEPROM_SIZE < size)
         return -1;
 
-    if (!memcmp((void*)address, data, size))
-        return -1;
+    /* 
+        Returns false results when changing only currPowerdB.
+        Commenting out for now to force writing.
+    */
+    // if (!memcmp((void*)address, data, size))
+    //     return -1;
 
     /* unlock the flash program/erase controller */
     fmc_unlock();

--- a/src/src/gd32f1x0/EEPROM.c
+++ b/src/src/gd32f1x0/EEPROM.c
@@ -62,6 +62,7 @@ static int flash_storage_write(uint32_t const * data, uint32_t size)
         }
         address += 4U;
         fmc_flag_clear(FMC_FLAG_END | FMC_FLAG_WPERR | FMC_FLAG_PGERR);
+        fwdgt_counter_reload();
     }
 
     /* lock the main FMC after the program operation */

--- a/src/src/gd32f1x0/gd32f1x0.c
+++ b/src/src/gd32f1x0/gd32f1x0.c
@@ -63,6 +63,11 @@ int main(void)
     (void)SCB->VTOR;
     __ISB();
 
+    fwdgt_config(0x0FFF, FWDGT_PSC_DIV4);
+    fwdgt_window_value_config(0x0FFF);
+    fwdgt_enable(); // Enable watchdog
+    fwdgt_counter_reload();
+
     SystemCoreClockUpdate();
     systick_config();
 

--- a/src/src/main.c
+++ b/src/src/main.c
@@ -56,8 +56,7 @@ void setup(void)
   target_rfPowerAmpPinSetup();
   rtc6705spiPinSetup();
 
-  // readEEPROM();
-  defaultEEPROM();
+  readEEPROM();
 
   pitMode = myEEPROM.pitmodeInRange;
 
@@ -71,17 +70,6 @@ void setup(void)
 #ifdef LED_INDICATION_OF_VTX_MODE
   resetModeIndication();
 #endif /* LED_INDICATION_OF_VTX_MODE */
-
-  // TODO DEBUG! Below flashing is just for testing. Delete later.
-#if DEBUG
-  myEEPROM.currFreq = 5600;
-  rtc6705WriteFrequency(myEEPROM.currFreq);
-
-  // target_set_power_dB(0);
-  target_set_power_dB(14);
-  // target_set_power_dB(20);
-  // target_set_power_dB(26);
-#endif /* DEBUG */
 }
 
 void loop(void)
@@ -123,16 +111,13 @@ void loop(void)
 
   errorCheck();
 
-  // writeEEPROM();
+  writeEEPROM();
 
   target_loop();
 
 #ifndef LED_INDICATION_OF_VTX_MODE
   status_led2(vtxModeLocked);
 #else
-  if (vtxModeLocked)
-  {
     modeIndicationLoop();
-  }
 #endif
 }

--- a/src/src/main.c
+++ b/src/src/main.c
@@ -35,7 +35,6 @@ static void start_serial(uint8_t type)
   }
   serial_begin(baud, UART_TX, UART_RX, stopbits);
   myEEPROM.vtxMode = type;
-  updateEEPROM = 1;
 }
 
 void checkRTC6705isAlive()

--- a/src/src/openVTxEEPROM.c
+++ b/src/src/openVTxEEPROM.c
@@ -1,12 +1,17 @@
+#include "common.h"
 #include "openVTxEEPROM.h"
 #include "targets.h"
 #include <EEPROM.h>
 
 
 openVTxEEPROM myEEPROM;
-uint32_t eeprom_last_write;
-uint8_t updateEEPROM;
+uint32_t updateEEPROMtime = 0;
 
+
+void updateEEPROM(void)
+{
+    updateEEPROMtime = millis();
+}
 
 void defaultEEPROM(void)
 {
@@ -21,7 +26,7 @@ void defaultEEPROM(void)
     myEEPROM.currPowermW = 25; // Required due to rounding errors when converting between dBm and mW
     myEEPROM.unlocked = 1;
 
-    updateEEPROM = 1;
+    updateEEPROM();
 }
 
 void readEEPROM(void)
@@ -31,15 +36,19 @@ void readEEPROM(void)
     if (myEEPROM.version != versionEEPROM) {
         defaultEEPROM();
     }
-    eeprom_last_write = millis();
 }
 
 void writeEEPROM(void)
 {
-    uint32_t const now = millis();
-    if (updateEEPROM && 1000 <= (now - eeprom_last_write)) {
+    if (updateEEPROMtime && (millis() - updateEEPROMtime) > 1000) {
         EEPROM_put(0, myEEPROM);
-        updateEEPROM = 0;
-        eeprom_last_write = now;
+        updateEEPROMtime = 0;
+
+        for (uint8_t i = 0; i < 4; i++){
+            delay(50);
+            status_led1(0);
+            delay(50);
+            status_led1(1);
+        }
     }
 }

--- a/src/src/openVTxEEPROM.c
+++ b/src/src/openVTxEEPROM.c
@@ -12,13 +12,13 @@ void defaultEEPROM(void)
 {
     myEEPROM.version = versionEEPROM;
     myEEPROM.vtxMode = TRAMP;
-    myEEPROM.currFreq = BOOT_FREQ;
-    myEEPROM.channel = 255;
+    myEEPROM.currFreq = 5800;
+    myEEPROM.channel = 27; // F4
     myEEPROM.freqMode = 0;
     myEEPROM.pitmodeInRange = 0;
     myEEPROM.pitmodeOutRange = 0;
-    myEEPROM.currPowerdB = 0;
-    myEEPROM.currPowermW = 0; // Required due to rounding errors when converting between dBm and mW
+    myEEPROM.currPowerdB = 14;
+    myEEPROM.currPowermW = 25; // Required due to rounding errors when converting between dBm and mW
     myEEPROM.unlocked = 1;
 
     updateEEPROM = 1;

--- a/src/src/openVTxEEPROM.c
+++ b/src/src/openVTxEEPROM.c
@@ -40,10 +40,15 @@ void readEEPROM(void)
 
 void writeEEPROM(void)
 {
+    // Dont write if no protocol has been detected, as nothing has changed. 
+    if (!vtxModeLocked)
+        updateEEPROMtime = 0;
+
     if (updateEEPROMtime && (millis() - updateEEPROMtime) > 1000) {
         EEPROM_put(0, myEEPROM);
         updateEEPROMtime = 0;
 
+        // Red LED blinks a couple of times as a visual indication.
         for (uint8_t i = 0; i < 4; i++){
             delay(50);
             status_led1(0);

--- a/src/src/openVTxEEPROM.h
+++ b/src/src/openVTxEEPROM.h
@@ -2,9 +2,7 @@
 
 #include <stdint.h>
 
-#define versionEEPROM 0x110
-
-#define BOOT_FREQ 5000
+#define versionEEPROM 0x111
 
 extern uint8_t updateEEPROM;
 

--- a/src/src/openVTxEEPROM.h
+++ b/src/src/openVTxEEPROM.h
@@ -4,7 +4,7 @@
 
 #define versionEEPROM 0x111
 
-extern uint8_t updateEEPROM;
+uint32_t updateEEPROMtime;
 
 typedef enum
 {
@@ -30,6 +30,7 @@ typedef struct
 
 extern openVTxEEPROM myEEPROM;
 
+void updateEEPROM(void);
 void defaultEEPROM(void);
 void readEEPROM(void);
 void writeEEPROM(void);

--- a/src/src/rtc6705.c
+++ b/src/src/rtc6705.c
@@ -142,7 +142,7 @@ uint8_t rtc6705CheckFrequency()
 void rtc6705WriteFrequency(uint32_t newFreq)
 {
   myEEPROM.currFreq = newFreq;
-  updateEEPROM = 1;
+  updateEEPROM();
 
   uint32_t freq = newFreq * 1000U;
   freq /= 40;

--- a/src/src/smartAudio.c
+++ b/src/src/smartAudio.c
@@ -283,7 +283,7 @@ void smartaudioProcessModePacket(void)
         setPowerdB(myEEPROM.currPowerdB);
     }
 
-    updateEEPROM = 1;
+    updateEEPROM();
 
     bitWrite(operationMode, 0, myEEPROM.pitmodeInRange);
     bitWrite(operationMode, 1, myEEPROM.pitmodeOutRange);

--- a/src/src/smartAudio.c
+++ b/src/src/smartAudio.c
@@ -158,8 +158,6 @@ void smartaudioBuildSettingsPacket(void)
 
 void smartaudioProcessFrequencyPacket(void)
 {
-    initFreqPacketRecived = 1;
-
     sa_u16_resp_t * payload =
         (sa_u16_resp_t*)fill_resp_header(
             SA_CMD_SET_FREQ, sizeof(sa_u16_resp_t));
@@ -192,8 +190,6 @@ void smartaudioProcessFrequencyPacket(void)
 
 void smartaudioProcessChannelPacket(void)
 {
-    initFreqPacketRecived = 1;
-
     sa_u8_resp_t * payload =
         (sa_u8_resp_t*)fill_resp_header(
             SA_CMD_SET_CHAN, sizeof(sa_u8_resp_t));

--- a/src/src/tramp.c
+++ b/src/src/tramp.c
@@ -86,8 +86,6 @@ void trampBuildsPacket(void)
 
 void trampProcessFPacket(void)
 {
-    initFreqPacketRecived = 1;
-
     uint32_t freq = rxPacket[3];
     freq <<= 8;
     freq |= rxPacket[2];

--- a/src/src/tramp.c
+++ b/src/src/tramp.c
@@ -119,7 +119,7 @@ void trampProcessIPacket(void)
     myEEPROM.pitmodeInRange = pitMode;  // Pitmode set via CMS is not remembered with Tramp, but I have forced it here to be useful like SA pitmode.
     myEEPROM.pitmodeOutRange = 0;       // Set to 0 so only one of PIR or POR is set for smartaudio
 
-    updateEEPROM = 1;
+    updateEEPROM();
 }
 
 enum {


### PR DESCRIPTION
This PR adds WD setup and reloading.  It looks like this was missing compared to the BL code, and may have been the reason for weird results when flashing via st link and no BL.

Excess var have been removed and the default settings are F4, 25mW, no pitmode.

This PR also allows for standalone VTx and the use of a button.  So if someone wants to add a button menu, go for it!

It could still do with some user testing to confirm everything is looking ok and the binaries attached can be flashed using https://openvtx.org/

[binaries.zip](https://github.com/OpenVTx/OpenVTx/files/9148311/binaries.zip)