### PR TITLE
fix-LED_INDICATION_OF_VTX_MODE-for-TRAMP

### DIFF
--- a/src/platformio.ini
+++ b/src/platformio.ini
@@ -7,6 +7,7 @@ build_flags =
 	-D DEBUG=0
 	-D OUTPUT_POWER_TESTING=0
 	-D OFFSET=0.0 # dBm cal correction.  -ve and +ve offsets allowed.
+	-D LED_INDICATION_OF_VTX_MODE=1
 
 # -----------------------------
 

--- a/src/src/button.c
+++ b/src/src/button.c
@@ -78,8 +78,6 @@ void checkButton(void)
             rtc6705WriteFrequency(channelFreqTable[myEEPROM.channel]);
         }
 
-        #ifdef LED_INDICATION_OF_VTX_MODE
         resetModeIndication();
-        #endif
     }
 }

--- a/src/src/common.h
+++ b/src/src/common.h
@@ -18,8 +18,6 @@
 #define IS_FACTORY_BAND                 0
 #define CHANNEL_COUNT                   8
 
-// #define LED_INDICATION_OF_VTX_MODE
-
 extern uint8_t rxPacket[64];
 extern uint8_t txPacket[64];
 #define FREQ_TABLE_SIZE 48

--- a/src/src/main.c
+++ b/src/src/main.c
@@ -9,10 +9,7 @@
 #include "errorCodes.h"
 #include "gpio.h"
 #include "button.h"
-
-#ifdef LED_INDICATION_OF_VTX_MODE
 #include "modeIndicator.h"
-#endif
 
 #if !DEBUG
 static uint32_t protocol_checked;
@@ -73,9 +70,7 @@ void setup(void)
   status_leds_init();
   button_init();
 
-#ifdef LED_INDICATION_OF_VTX_MODE
   resetModeIndication();
-#endif /* LED_INDICATION_OF_VTX_MODE */
 }
 
 void loop(void)
@@ -140,9 +135,12 @@ void loop(void)
 
   target_loop();
 
-#ifndef LED_INDICATION_OF_VTX_MODE
-  status_led2(vtxModeLocked);
-#else
+  if (LED_INDICATION_OF_VTX_MODE && vtxModeLocked && myEEPROM.vtxMode != TRAMP) // TRAMP doesnt use VTx Tables so LED indication of band/channel doesnt really work.
+  {
     modeIndicationLoop();
-#endif
+  }
+  else
+  {
+    status_led2(vtxModeLocked);
+  }
 }

--- a/src/src/smartAudio.c
+++ b/src/src/smartAudio.c
@@ -329,9 +329,9 @@ void smartaudioProcessSerial(void)
             case SA_CRC:
                 // CRC check and packet processing
                 if (smartadioCalcCrc(rxPacket, in_len) == data) {
-                    #ifndef LED_INDICATION_OF_VTX_MODE
-                    status_led3(1);
-                    #endif
+                    if (!LED_INDICATION_OF_VTX_MODE)
+                        status_led3(1);
+                    
                     vtxModeLocked = 1; // Successfully got a packet so lock VTx mode.
 
                     switch (rxPacket[2] >> 1) // Commands
@@ -356,9 +356,8 @@ void smartaudioProcessSerial(void)
                             reboot_into_bootloader(4801); // LSB represents stopbits. 0 = 1 stopbit, 1 = 2 stopbit.  SA passthrough requires 2 stopbits.
                         break;
                     }
-                    #ifndef LED_INDICATION_OF_VTX_MODE
-                    status_led3(0);
-                    #endif
+                    if (!LED_INDICATION_OF_VTX_MODE)
+                        status_led3(0);
                 }
                 break;
             default:

--- a/src/src/tramp.c
+++ b/src/src/tramp.c
@@ -151,9 +151,8 @@ void trampProcessSerial(void)
                 break;
             case TRAMP_CRC:
                 if (data == trampCalcCrc(rxPacket)) {
-                    #ifndef LED_INDICATION_OF_VTX_MODE
                     status_led3(1);
-                    #endif
+                    
                     vtxModeLocked = 1; // Successfully got a packet so lock VTx mode.
 
                     switch (rxPacket[1]) // command
@@ -181,9 +180,8 @@ void trampProcessSerial(void)
                             reboot_into_bootloader(9600);
                         break;
                     }
-                    #ifndef LED_INDICATION_OF_VTX_MODE
+                    
                     status_led3(0);
-                    #endif
                 }
                 in_idx = 0;
                 state = TRAMP_SYNC;


### PR DESCRIPTION
TRAMP does not use a vtx table so the LEDs will not flash correctly if a non standard vtx table is used.