### PR TITLE
fix leds blinking

### DIFF
--- a/src/src/main.c
+++ b/src/src/main.c
@@ -138,7 +138,7 @@ void loop(void)
 
   target_loop();
 
-  if (LED_INDICATION_OF_VTX_MODE && vtxModeLocked && myEEPROM.vtxMode != TRAMP) // TRAMP doesnt use VTx Tables so LED indication of band/channel doesnt really work.
+  if (LED_INDICATION_OF_VTX_MODE && !(vtxModeLocked && myEEPROM.vtxMode == TRAMP)) // TRAMP doesnt use VTx Tables so LED indication of band/channel doesnt really work.
   {
     modeIndicationLoop();
   }


### PR DESCRIPTION
Previously the LEDs would not flash until a tlm protocol had been detected, or the button was pressed.  Pressing the button is not only a PITA, but it would also change the channel you had set.  This is annoying for anyone not use a FC and tlm protocol for control.

Now the LEDs will always blink on boot indicating the band, channel, and power.

The Tramp protocol does not use the LEDs in this manner due to having a non fixed VTx table.

More info on the LEDs here https://github.com/OpenVTx/OpenVTx#normal-mode