### PR TITLE
Lock stm32duino version to 1.0.1

### DIFF
--- a/src/platformio.ini
+++ b/src/platformio.ini
@@ -51,7 +51,7 @@ platform_packages =
     maxgerhardt/framework-spl@2.10300.0
     platformio/tool-dfuutil@1.11.0
     platformio/tool-openocd@2.1100.211028
-    platformio/tool-stm32duino
+    platformio/tool-stm32duino@1.0.1
     platformio/toolchain-gccarmnoneeabi@1.70201.0
 framework = spl
 board = gd32f130g6

--- a/src/platformio.ini
+++ b/src/platformio.ini
@@ -51,7 +51,7 @@ platform_packages =
     maxgerhardt/framework-spl@2.10300.0
     platformio/tool-dfuutil@1.11.0
     platformio/tool-openocd@2.1100.211028
-	platformio/tool-stm32duino@1.0.2
+    platformio/tool-stm32duino
     platformio/toolchain-gccarmnoneeabi@1.70201.0
 framework = spl
 board = gd32f130g6


### PR DESCRIPTION
The most recent [stm32duino](https://registry.platformio.org/tools/platformio/tool-stm32duino/compatibility) release 1.0.2 is not compatible with github builds.

```
Tool Manager: Installing platformio/tool-stm32duino @ 1.0.2
UnknownPackageError: Could not find the package with 'platformio/tool-stm32duino @ 1.0.2' requirements for your system 'linux_x86_64'
Error: Process completed with exit code 1.
```

1.0.1 should be ok since current releases would have been built using this version.  BUT, we need to do some checks before merging.

