### PR TITLE
Use pullup for button

### DIFF
--- a/src/src/button.c
+++ b/src/src/button.c
@@ -28,7 +28,7 @@ uint8_t previous_button_state = BUTTON_RELEASED;
 
 void button_init(void)
 {
-    buttonPin = gpio_in_setup(BUTTON, 0);
+    buttonPin = gpio_in_setup(BUTTON, 1);
 }
 
 void checkButton(void)


### PR DESCRIPTION
As mentioned in #71 I experience channel changes on boot when not connected to SmartAudio. On the Fyujon v1, v2, and OVX303 v1.2 that I own, the button's high side is connected directly to the MCU's PA6, and the low side is connected through a 200 ohm resistor to ground. This means that the active side of the button is essentially floating. I'm not sure what the purpose of the 200 ohm resistor to ground is on the other side. While it is floating, the motor beeps on startup can generate enough voltage that the button gets triggered and it switches channels. Enough boots you even leave the raceband and go to lowband and it seems like the VTX isn't working at all any more.

This PR changes to code to enable the STM32's internal pullup on the button pin so it is pulled high and will function properly (at least with Fyujon/OVX303 hardware). On other hardware, if the button is already pulled up, then this probably won't hurt, as it will just form a weaker pullup which should still work (?). 

In any case, I've been chasing this problem for over a year now where I had a Fyujon I thought was broken because sometimes it would just be on a different channel. Turns out it was just a loose SmartAudio wire. I broke the SmartAudio wire at a race and both my quads started jumping channels and it lead me to that flippin' button.